### PR TITLE
v1.2.0 - Handle specific config for plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amphore-dev/architect",
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Amphore-Dev/Architect.git"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"license": "MIT",
 	"description": "A CLI tool to generate React components",
 	"main": "dist/index.js",
+	"types": "dist/declarations/index.d.ts",
 	"bin": {
 		"architect": "dist/index.js"
 	},

--- a/src/classes/ContextClass.ts
+++ b/src/classes/ContextClass.ts
@@ -25,6 +25,7 @@ class Context {
 	public async init(options: TOptions = {}): Promise<TConfig> {
 		this.loadConfig(options.config, options);
 		await this.loadPlugins();
+		this.loadConfig(options.config, options); // Reload config to include plugin configs
 		return this.getConfig();
 	}
 

--- a/src/types/TPlugins.ts
+++ b/src/types/TPlugins.ts
@@ -1,10 +1,12 @@
+import { TConfig } from "./TConfig";
 import { TFileExtensions } from "./TFileExtensions";
 
 export type TArchitectPlugin = {
 	name: string; // the plugin's name
-	destination: string; // the destination folder name for the plugin files
-	register: (architect: TArchitectPluginAPI) => void; // the plugin's registration function
+	destination?: string; // the destination folder name for the plugin files
+	register?: (architect: TArchitectPluginAPI) => void; // the plugin's registration function
 	extensions?: string | TFileExtensions; // the file extensions supported by the plugin
+	config?: TConfig;
 };
 
 export type TArchitectPluginAPI = {

--- a/src/types/TPlugins.ts
+++ b/src/types/TPlugins.ts
@@ -6,7 +6,7 @@ export type TArchitectPlugin = {
 	destination?: string; // the destination folder name for the plugin files
 	register?: (architect: TArchitectPluginAPI) => void; // the plugin's registration function
 	extensions?: string | TFileExtensions; // the file extensions supported by the plugin
-	config?: TConfig;
+	config?: TConfig; // the plugin's configuration object that will be merged with the CLI's configuration
 };
 
 export type TArchitectPluginAPI = {

--- a/src/utils/UConfig.ts
+++ b/src/utils/UConfig.ts
@@ -1,30 +1,42 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import ContextClass from "../classes/ContextClass";
 import { DEFAULT_CONFIG, INVALID_CONFIG_FILE } from "../constants";
 import { TConfig, TOptions } from "../types";
 import { errorLog, infoLog } from "./ULogs";
+import { mergeObjects } from "./UObjects";
 
 export function loadConfig(
 	_configPath: string = "architect.config.json",
 	options: TOptions = {}
 ): TConfig {
+	const plugins = ContextClass.getPlugins();
+
+	// reduce all plugins.config to a single object
+	const pluginConfigs = plugins.reduce((acc, plugin) => {
+		return { ...acc, ...plugin.config };
+	}, {});
+
 	const configPath = path.resolve(process.cwd(), _configPath);
 
 	if (fs.existsSync(configPath)) {
-		infoLog("Config file found");
 		try {
 			const userConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-			return {
-				...DEFAULT_CONFIG,
-				...userConfig,
-				options,
-				outputDir:
-					options.output ??
-					userConfig.outputDir ??
-					DEFAULT_CONFIG.outputDir ??
-					"",
-			};
+
+			return mergeObjects<TConfig>(
+				DEFAULT_CONFIG,
+				pluginConfigs,
+				userConfig,
+				{ options },
+				{
+					outputDir:
+						options.output ??
+						userConfig.outputDir ??
+						DEFAULT_CONFIG.outputDir ??
+						"",
+				}
+			);
 		} catch {
 			errorLog(`Error parsing config file '${_configPath}'`);
 			process.exit(INVALID_CONFIG_FILE);

--- a/src/utils/UObjects.ts
+++ b/src/utils/UObjects.ts
@@ -1,0 +1,27 @@
+export function mergeObjects<T extends object>(...sources: Partial<T>[]): T {
+	const target = {} as Partial<T>;
+	sources.forEach((source) => {
+		if (!source || typeof source !== "object") return;
+
+		Object.keys(source).forEach((key) => {
+			const sourceValue = source[key as keyof T];
+			const targetValue = target[key as keyof T];
+
+			// Recursively merge if both target and source are objects
+			if (
+				sourceValue instanceof Object &&
+				targetValue instanceof Object
+			) {
+				target[key as keyof T] = mergeObjects(
+					targetValue as Partial<T[keyof T]>,
+					sourceValue as Partial<T[keyof T]>
+				) as T[keyof T];
+			} else {
+				// Otherwise, assign the source value to the target
+				target[key as keyof T] = sourceValue as T[keyof T];
+			}
+		});
+	});
+
+	return target as T;
+}

--- a/src/utils/UPlugins.ts
+++ b/src/utils/UPlugins.ts
@@ -19,9 +19,10 @@ export async function loadNpmPlugins(
 				pluginModule.default || pluginModule;
 
 			// Register the plugin with Architect API
-			if (plugin && plugin.register) {
+			if (plugin) {
 				const pluginAPIObject = new ArchitectPlugin(dep, plugin);
-				plugin.register(pluginAPIObject);
+
+				plugin.register?.(pluginAPIObject);
 				plugins.push(plugin);
 			} else {
 				warningLog(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./UImports";
 export * from "./ULogs";
 export * from "./UStrings";
 export * from "./UStructure";
+export * from "./UObjects";


### PR DESCRIPTION
**updated TArchitectPlugin**

- new `config`prop
- optional `register`prop

  ``` typescript
  export type TArchitectPlugin = {
	  name: string; // the plugin's name
	  destination?: string; // the destination folder name for the plugin files
	  register?: (architect: TArchitectPluginAPI) => void; // the plugin's registration function
	  extensions?: string | TFileExtensions; // the file extensions supported by the plugin
	  config?: TConfig; // the plugin's configuration object that will be merged with the CLI's configuration
  };

**fixed types definitions**